### PR TITLE
Update dockerfile for MISP modules

### DIFF
--- a/modules/Dockerfile
+++ b/modules/Dockerfile
@@ -18,8 +18,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     RUN git clone https://github.com/stricaud/faup.git
     WORKDIR /srv/faup/build
     RUN cmake .. && make
-    RUN sudo make install
-    RUN sudo ldconfig
+    RUN make install
+    RUN ldconfig
     WORKDIR /srv/faup/src/lib/bindings/python
     RUN pip3 wheel --no-cache-dir -w /wheel/ .
     RUN git clone --branch ${MISP_TAG} --depth 1  https://github.com/MISP/misp-modules.git

--- a/modules/Dockerfile
+++ b/modules/Dockerfile
@@ -15,9 +15,17 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 # Build MISP Modules
     WORKDIR /srv
+    RUN git clone https://github.com/stricaud/faup.git
+    WORKDIR /srv/faup/build
+    RUN cmake .. && make
+    RUN sudo make install
+    RUN sudo ldconfig
+    WORKDIR /srv/faup/src/lib/bindings/python
+    RUN pip3 wheel --no-cache-dir -w /wheel/ .
     RUN git clone --branch ${MISP_TAG} --depth 1  https://github.com/MISP/misp-modules.git
     RUN mkdir /wheel
     WORKDIR /srv/misp-modules
+    RUN touch misp_modules/modules/expansion/_ransomcoindb/__init__.py
     RUN sed -i 's/-e //g' REQUIREMENTS
     RUN pip3 wheel -r REQUIREMENTS --no-cache-dir -w /wheel/
 

--- a/modules/Dockerfile
+++ b/modules/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
                 pkg-config \
                 libpoppler-cpp-dev \
                 libfuzzy-dev \
-                cmake
+                cmake \
             && apt-get autoremove -y && apt-get clean -y && rm -rf /var/lib/apt/lists/*
 
 # Build MISP Modules

--- a/modules/Dockerfile
+++ b/modules/Dockerfile
@@ -17,17 +17,18 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Build MISP Modules
     WORKDIR /srv
     RUN mkdir /wheel
-    RUN git clone https://github.com/stricaud/faup.git
+    RUN git clone --depth 1 https://github.com/stricaud/faup.git
     WORKDIR /srv/faup/build
     RUN cmake .. && make
     RUN make install
     RUN ldconfig
     WORKDIR /srv/faup/src/lib/bindings/python
     RUN pip3 wheel --no-cache-dir -w /wheel/ .
+    WORKDIR /srv
     RUN git clone --branch ${MISP_TAG} --depth 1  https://github.com/MISP/misp-modules.git
     WORKDIR /srv/misp-modules
     RUN touch misp_modules/modules/expansion/_ransomcoindb/__init__.py
-    RUN sed -i 's/-e //g' REQUIREMENTS
+    # RUN sed -i 's/-e //g' REQUIREMENTS
     RUN pip3 wheel -r REQUIREMENTS --no-cache-dir -w /wheel/
 
 FROM python:3.7-slim-buster

--- a/modules/Dockerfile
+++ b/modules/Dockerfile
@@ -11,6 +11,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
                 pkg-config \
                 libpoppler-cpp-dev \
                 libfuzzy-dev \
+                cmake
             && apt-get autoremove -y && apt-get clean -y && rm -rf /var/lib/apt/lists/*
 
 # Build MISP Modules

--- a/modules/Dockerfile
+++ b/modules/Dockerfile
@@ -16,6 +16,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 # Build MISP Modules
     WORKDIR /srv
+    RUN mkdir /wheel
     RUN git clone https://github.com/stricaud/faup.git
     WORKDIR /srv/faup/build
     RUN cmake .. && make
@@ -24,7 +25,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     WORKDIR /srv/faup/src/lib/bindings/python
     RUN pip3 wheel --no-cache-dir -w /wheel/ .
     RUN git clone --branch ${MISP_TAG} --depth 1  https://github.com/MISP/misp-modules.git
-    RUN mkdir /wheel
     WORKDIR /srv/misp-modules
     RUN touch misp_modules/modules/expansion/_ransomcoindb/__init__.py
     RUN sed -i 's/-e //g' REQUIREMENTS


### PR DESCRIPTION
Workaround issues reported in https://github.com/MISP/misp-modules/issues/354

- Use `touch` to add missing `misp_modules/modules/expansion/_ransomcoindb/__init__.py` that prevents the service from starting
- Install `faup` and Python bindings