### PR TITLE
Prevent runaway mysql log

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,8 @@ services:
       - "MYSQL_DATABASE=misp"
     volumes:
       - mysql_data:/var/lib/mysql
+    cap_add:
+      - SYS_NICE  # CAP_SYS_NICE Prevent runaway mysql log
 
   misp:
     image: coolacid/misp-docker:core-latest


### PR DESCRIPTION
We recently ran into an issue where the mysql console output was filling up the disk with

> mbind: Operation not permitted

It turns out this is a common problem with the `mysql` docker image. This is the fix.

https://stackoverflow.com/questions/55559386/how-to-fix-mbind-operation-not-permitted-in-mysql-error-log