### PR TITLE
Fix docker volume persistent for directory of custom org images.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,8 @@ services:
       - "./logs/:/var/www/MISP/app/tmp/logs/"
       - "./files/:/var/www/MISP/app/files"
       - "./ssl/:/etc/nginx/certs"
+      - "custom_org_images:/var/www/MISP/app/webroot/img/orgs"
+      - "custom_images:/var/www/MISP/app/webroot/img/custom"
 #      - "./examples/custom-entrypoint.sh:/custom-entrypoint.sh" # Use the example custom-entrypoint.sh
     environment:
       - "HOSTNAME=https://localhost"
@@ -63,3 +65,5 @@ services:
 
 volumes:
     mysql_data:
+    custom_org_images:
+    custom_images:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,13 +45,14 @@ services:
       # Database Configuration (And their defaults)
 #      - "MYSQL_HOST=db"
 #      - "MYSQL_USER=misp"
-#      - "MYSQL_PASSWORD=example" # NOTE: This should be AlphaNum with no Special Chars. Otherwise, edit config files after first run. 
+#      - "MYSQL_PASSWORD=example" # NOTE: This should be AlphaNum with no Special Chars. Otherwise, edit config files after first run.
 #      - "MYSQL_DATABASE=misp"
       # Optional Settings
 #      - "NOREDIR=true" # Do not redirect port 80
 #      - "DISIPV6=true" # Disable IPV6 in nginx
 #      - "SECURESSL=true" # Enable higher security SSL in nginx
 #      - "MISP_MODULES_FQDN=http://misp-modules" # Set the MISP Modules FQDN, used for Enrichment_services_url/Import_services_url/Export_services_url
+#      - "ADMIN_PASSWORD=xxx" set temp password for the default user admin@admin.test only if INIT=true. Must comply with the password requirements in MISP.
   misp-modules:
     image: coolacid/misp-docker:modules-latest
     environment:

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -73,6 +73,7 @@ ARG PHP_VER
         supervisor \
         git \
         cron \
+        curl \
         openssl \
         gpg-agent gpg \
         ssdeep \

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -134,6 +134,9 @@ ARG PHP_VER
 # Make a copy of the configurations, so we can sync from it
     RUN cp -R /var/www/MISP/app/Config /var/www/MISP/app/Config.dist
 
+# Make a copy of the default images of orgs, so we can sync from it
+    RUN cp -R /var/www/MISP/app/webroot/img/orgs /var/www/MISP/app/webroot/img/orgs.dist
+
 # Entrypoints
     COPY files/etc/supervisor/supervisor.conf /etc/supervisor/conf.d/supervisord.conf
     COPY files/entrypoint_fpm.sh /

--- a/server/files/entrypoint_nginx.sh
+++ b/server/files/entrypoint_nginx.sh
@@ -198,6 +198,12 @@ update_misp_submodules() {
   curl -s http://localhost/users/login > /dev/null
   curl -s --insecure https://localhost/users/login > /dev/null
 
+  # only on init and admin password variable not blank
+  if [ -n "$ADMIN_PASSWORD" ]; then
+    echo "setting new admin password"
+    /var/www/MISP/app/Console/cake Password admin@admin.test "$ADMIN_PASSWORD"
+  fi
+
   echo "Update Taxonomies"
   /var/www/MISP/app/Console/cake Admin updateTaxonomies
   echo "Update WarningLists"

--- a/server/files/entrypoint_nginx.sh
+++ b/server/files/entrypoint_nginx.sh
@@ -104,6 +104,7 @@ sync_files(){
     for DIR in $(ls /var/www/MISP/app/files.dist); do
         rsync -azh --delete "/var/www/MISP/app/files.dist/$DIR" "/var/www/MISP/app/files/"
     done
+    cp /var/www/MISP/app/webroot/img/orgs.dist/* /var/www/MISP/app/webroot/img/orgs
 }
 
 # Ensure SSL certs are where we expect them, for backward comparibility See issue #53

--- a/server/files/entrypoint_nginx.sh
+++ b/server/files/entrypoint_nginx.sh
@@ -189,5 +189,32 @@ if [[ "$WARNING53" == true ]]; then
     echo "WARNING - WARNING - WARNING"
 fi
 
-# Start NGINX
+# can run fine in the background
+update_misp_submodules() {
+  echo "updating submodules. The first time will take a while."
+  # wait 5 seconds for nginx start up
+  sleep 5s
+  # request is needed because misp will not update itself without request
+  curl -s http://localhost/users/login > /dev/null
+  curl -s --insecure https://localhost/users/login > /dev/null
+
+  echo "Update Taxonomies"
+  /var/www/MISP/app/Console/cake Admin updateTaxonomies
+  echo "Update WarningLists"
+  /var/www/MISP/app/Console/cake Admin updateWarningLists
+  echo "Update NoticeLists"
+  /var/www/MISP/app/Console/cake Admin updateNoticeLists
+  echo "Update ObjectTemplates"
+  /var/www/MISP/app/Console/cake Admin updateObjectTemplates
+  echo "Update Galaxies"
+  # bug issue (https://github.com/MISP/MISP/issues/6921) | only succeeds after loading the webpage once
+  /var/www/MISP/app/Console/cake Admin updateGalaxies
+  echo "done updating"
+}
+
+if [[ "$INIT" == true ]]; then
+  update_misp_submodules &
+fi
+
+echo "starting nginx"
 nginx -g 'daemon off;'


### PR DESCRIPTION
Before uploaded images for misp organisation were lost after removing the docker container .
Now the default content of the directory is not synced with docker volume directory.

sync /var/www/MISP/app/webroot/img/orgs images from MISPs Github Repo to allow using a docker volume to persist uploaded data.