### PR TITLE
Make every MISP setting customizable by environment variables.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,13 +45,15 @@ services:
       # Database Configuration (And their defaults)
 #      - "MYSQL_HOST=db"
 #      - "MYSQL_USER=misp"
-#      - "MYSQL_PASSWORD=example" # NOTE: This should be AlphaNum with no Special Chars. Otherwise, edit config files after first run. 
+#      - "MYSQL_PASSWORD=example" # NOTE: This should be AlphaNum with no Special Chars. Otherwise, edit config files after first run.
 #      - "MYSQL_DATABASE=misp"
       # Optional Settings
 #      - "NOREDIR=true" # Do not redirect port 80
 #      - "DISIPV6=true" # Disable IPV6 in nginx
 #      - "SECURESSL=true" # Enable higher security SSL in nginx
 #      - "MISP_MODULES_FQDN=http://misp-modules" # Set the MISP Modules FQDN, used for Enrichment_services_url/Import_services_url/Export_services_url
+#      - "M_S_MISP.live=true"
+#      - "M_S_Plugin.CustomAuth_enable=true"
   misp-modules:
     image: coolacid/misp-docker:modules-latest
     environment:

--- a/server/files/entrypoint_nginx.sh
+++ b/server/files/entrypoint_nginx.sh
@@ -50,6 +50,13 @@ init_misp_config(){
     /var/www/MISP/app/Console/cake Admin setSetting "Plugin.Export_services_url" "$MISP_MODULES_FQDN"
 
     /var/www/MISP/app/Console/cake Admin setSetting "Plugin.Cortex_services_enable" false
+
+    # iterate over every environment variable starting with "M_S_" and parsing it to key value pair to execute cake setting
+    for var in $(env | grep M_S_); do
+      param1=$(echo $var | sed -r 's/M_S_//g' | sed -r 's/=(.*)//g' | sed 's/\././g')
+      param2=$(echo $var | sed -r 's/M_S_(.*)=//g')
+      /var/www/MISP/app/Console/cake Admin setSetting "${param1}" "${param2}"
+    done
 }
 
 init_misp_files(){


### PR DESCRIPTION
the ngix entrypoint iterates over every suitable misp settings variable and parses the relevant arguments.

This pull quest allows the user to set every MISP config by environment variables.
Every environment variable set must start with "M_S_" following by the misp setting. The value of the environment variable is the value set in MISP. 

