### PR TITLE
dynamically create crontab entries based on cake output for sync servers

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,7 +41,6 @@ services:
       - "REDIS_FQDN=redis"
       - "INIT=true"             # Initialze MISP, things includes, attempting to import SQL and the Files DIR
       - "CRON_USER_ID=1"        # The MISP user ID to run cron jobs as
-#      - "SYNCSERVERS=1 2 3 4"  # The MISP Feed servers to sync in the cron job
       # Database Configuration (And their defaults)
 #      - "MYSQL_HOST=db"
 #      - "MYSQL_USER=misp"

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -88,6 +88,7 @@ ARG PHP_VER
         # Requirements:
         procps \
         sudo \
+        curl \
         nginx \
         supervisor \
         git \
@@ -95,6 +96,7 @@ ARG PHP_VER
         openssl \
         gpg-agent gpg \
         ssdeep \
+        jq \
         libfuzzy2 \
         mariadb-client \
         rsync \

--- a/server/files/entrypoint_cron.sh
+++ b/server/files/entrypoint_cron.sh
@@ -1,7 +1,13 @@
 #!/bin/bash
 
+sleep 30
+until curl --output /dev/null --insecure --silent --head --fail https://localhost:443; do
+  echo 'waiting for nginx to startup to setup crontabs'
+  sleep 10
+done
+
 # Create the misp cron tab
-cat << EOF > /etc/cron.d/misp
+cat <<EOF >/etc/cron.d/misp
 20 2 * * * www-data /var/www/MISP/app/Console/cake Server cacheFeed "$CRON_USER_ID" all >/tmp/cronlog 2>/tmp/cronlog
 30 2 * * * www-data /var/www/MISP/app/Console/cake Server fetchFeed "$CRON_USER_ID" all >/tmp/cronlog 2>/tmp/cronlog
 
@@ -9,27 +15,24 @@ cat << EOF > /etc/cron.d/misp
 10 3 * * * www-data /var/www/MISP/app/Console/cake Admin updateTaxonomies >/tmp/cronlog 2>/tmp/cronlog
 20 3 * * * www-data /var/www/MISP/app/Console/cake Admin updateWarningLists >/tmp/cronlog 2>/tmp/cronlog
 30 3 * * * www-data /var/www/MISP/app/Console/cake Admin updateNoticeLists >/tmp/cronlog 2>/tmp/cronlog
-45 3 * * * www-data /var/www/MISP/app/Console/cake Admin updateObjectTemplates >/tmp/cronlog 2>/tmp/cronlog
+45 3 * * * www-data /var/www/MISP/app/Console/cake Admin updateObjectTemplates 1 >/tmp/cronlog 2>/tmp/cronlog
 
 EOF
-
-if [ ! -z "$SYNCSERVERS" ];
-then
-    TIME=0
-    for SYNCSERVER in $SYNCSERVERS
-    do
-cat << EOF >> /etc/cron.d/misp
-$TIME 0 * * * www-data /var/www/MISP/app/Console/cake Server pull "$CRON_USER_ID" "$SYNCSERVER">/tmp/cronlog 2>/tmp/cronlog
-$TIME 1 * * * www-data /var/www/MISP/app/Console/cake Server push "$CRON_USER_ID" "$SYNCSERVER">/tmp/cronlog 2>/tmp/cronlog
+SERVERS=$(jq -r '.servers[].id' <<<"$(/var/www/MISP/app/Console/cake Server listServers -q)")
+TIME=0
+for SYNCSERVER in $SERVERS; do
+  echo "setting up cron for sync server $SYNCSERVER"
+  cat <<EOF >>/etc/cron.d/misp
+$TIME 0 * * * www-data /var/www/MISP/app/Console/cake Server pull "$CRON_USER_ID" "$SYNCSERVER" >/tmp/cronlog 2>/tmp/cronlog
+$TIME 1 * * * www-data /var/www/MISP/app/Console/cake Server push "$CRON_USER_ID" "$SYNCSERVER" >/tmp/cronlog 2>/tmp/cronlog
 EOF
 
-    ((TIME+=5))
-    done
-fi
+  ((TIME += 5))
+done
 
 # Build a fifo buffer for the cron logs, 777 so anyone can write to it
 if [[ ! -p /tmp/cronlog ]]; then
-    mkfifo /tmp/cronlog
+  mkfifo /tmp/cronlog
 fi
 chmod 777 /tmp/cronlog
 


### PR DESCRIPTION
Hello @coolacid,

I have created this pull request to to allow the crontabs for MISP to be generated automatically based on configured Sync Servers in MISP. 

Allows the removal of the environment variable: `SYNCSERVERS`

Also fixes:
https://github.com/coolacid/docker-misp/issues/99