### PR TITLE
Install dependencies for Open ID Connect implementation for MISP v2.4.140

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -2,7 +2,8 @@ FROM composer:1.9 as composer-build
     ARG MISP_TAG
     WORKDIR /tmp
     ADD https://raw.githubusercontent.com/MISP/MISP/${MISP_TAG}/app/composer.json /tmp
-    RUN composer install --ignore-platform-reqs
+    RUN composer install --ignore-platform-reqs && \
+     composer require jumbojett/openid-connect-php --ignore-platform-reqs
 
 FROM debian:buster-slim as php-build
     RUN apt-get update; apt-get install -y --no-install-recommends \
@@ -153,9 +154,6 @@ ARG PHP_VER
 
 # Make a copy of the configurations, so we can sync from it
     RUN cp -R /var/www/MISP/app/Config /var/www/MISP/app/Config.dist
-
-    # Intall Open ID Connect dependency
-    RUN cd /var/www/MISP/app && php composer.phar require jumbojett/openid-connect-php
 
 # Entrypoints
     COPY files/etc/supervisor/supervisor.conf /etc/supervisor/conf.d/supervisord.conf

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -103,6 +103,7 @@ ARG PHP_VER
         python3-pip \
         # PHP Requirements
         php \
+        php-curl \
         php-xml \
         php-intl \
         php-bcmath \
@@ -152,6 +153,9 @@ ARG PHP_VER
 
 # Make a copy of the configurations, so we can sync from it
     RUN cp -R /var/www/MISP/app/Config /var/www/MISP/app/Config.dist
+
+    # Intall Open ID Connect dependency
+    RUN cd /var/www/MISP/app && php composer.phar require jumbojett/openid-connect-php
 
 # Entrypoints
     COPY files/etc/supervisor/supervisor.conf /etc/supervisor/conf.d/supervisord.conf

--- a/server/files/etc/nginx/misp
+++ b/server/files/etc/nginx/misp
@@ -40,7 +40,7 @@ server {
     fastcgi_hide_header X-Powered-By;
 
     location / {
-        try_files $uri $uri/ /index.php;
+        try_files $uri $uri/ /index.php$is_args$query_string;
     }
 
     location ~ \.php$ {

--- a/server/files/etc/nginx/misp-secure
+++ b/server/files/etc/nginx/misp-secure
@@ -38,7 +38,7 @@ server {
     fastcgi_hide_header X-Powered-By;
 
     location / {
-        try_files $uri $uri/ /index.php;
+        try_files $uri $uri/ /index.php$is_args$query_string;
     }
 
     location ~ \.php$ {

--- a/server/files/etc/nginx/misp80-noredir
+++ b/server/files/etc/nginx/misp80-noredir
@@ -24,7 +24,7 @@ server {
     fastcgi_hide_header X-Powered-By;
 
     location / {
-        try_files $uri $uri/ /index.php;
+        try_files $uri $uri/ /index.php$is_args$query_string;
     }
 
     location ~ \.php$ {


### PR DESCRIPTION
Hello,

with MISP version 2.4.140 open id connect was implemented. This pull request installs the necessary dependencies and modifies the nginx files to allow integration.

Are you interested in adding this to your repo?
If yes I am more than happy to write a little setup guide in the readme file.


Tested with Keycloak as IDP.