### PR TITLE
Add required parameters for cert authentication

### DIFF
--- a/server/files/etc/nginx/misp
+++ b/server/files/etc/nginx/misp
@@ -45,6 +45,8 @@ server {
 
     location ~ \.php$ {
         include snippets/fastcgi-php.conf;
+        fastcgi_param SSL_CLIENT_I_DN $ssl_client_i_dn;
+        fastcgi_param SSL_CLIENT_S_DN $ssl_client_s_dn;
         fastcgi_pass unix:/var/run/php/php7.3-fpm.sock;
         fastcgi_read_timeout 300;
     }


### PR DESCRIPTION
CertAuth (https://github.com/MISP/MISP/tree/2.4/app/Plugin/CertAuth) expects SSL_CLIENT_I_DN and SSL_CLIENT_S_DN in order to authenticate users.