### PR TITLE
Add required parameters for cert authentication 

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Updating the images should be as simple as `docker-compose pull` which, unless c
 -   Directory volume mount SSL Certs `./ssl`: `/etc/ssl/certs`
     -   Certificate File: `cert.pem`
     -   Certificate Key File: `key.pem`
+    -   CA File for Cert Authentication (optional) `ca.pem`
 
 -   Directory volume mount and create configs: `/var/www/MISP/app/Config/`
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,6 +50,7 @@ services:
       # Optional Settings
 #      - "NOREDIR=true" # Do not redirect port 80
 #      - "DISIPV6=true" # Disable IPV6 in nginx
+#      - "CERTAUTH=optional" # Can be set to optional or on - Step 2 of https://github.com/MISP/MISP/tree/2.4/app/Plugin/CertAuth is still required
 #      - "SECURESSL=true" # Enable higher security SSL in nginx
 #      - "MISP_MODULES_FQDN=http://misp-modules" # Set the MISP Modules FQDN, used for Enrichment_services_url/Import_services_url/Export_services_url
   misp-modules:

--- a/server/files/entrypoint_nginx.sh
+++ b/server/files/entrypoint_nginx.sh
@@ -170,8 +170,8 @@ fi
 
 if [[ $CERTAUTH = @(optional|on) ]]; then
     echo "Configure NGINX | Enabling SSL Cert Authentication"
-    grep -qxF 'fastcgi_param SSL_CLIENT_I_DN $ssl_client_i_dn;' /etc/nginx/snippets/fastcgi-php.conf || echo 'fastcgi_param SSL_CLIENT_I_DN $ssl_client_i_dn;' >> /etc/nginx/snippets/fastcgi-php.conf
-    grep -qxF 'fastcgi_param SSL_CLIENT_S_DN $ssl_client_s_dn;' /etc/nginx/snippets/fastcgi-php.conf || echo 'fastcgi_param SSL_CLIENT_S_DN $ssl_client_s_dn;' >> /etc/nginx/snippets/fastcgi-php.conf
+    grep -qxF 'fastcgi_param SSL_CLIENT_I_DN $ssl_client_i_dn;' /etc/nginx/snippets/fastcgi-php.conf || echo "fastcgi_param SSL_CLIENT_I_DN \$ssl_client_i_dn;" >> /etc/nginx/snippets/fastcgi-php.conf
+    grep -qxF 'fastcgi_param SSL_CLIENT_S_DN $ssl_client_s_dn;' /etc/nginx/snippets/fastcgi-php.conf || echo "fastcgi_param SSL_CLIENT_S_DN \$ssl_client_s_dn;" >> /etc/nginx/snippets/fastcgi-php.conf
     grep -qF 'ssl_client_certificate' /etc/nginx/sites-enabled/misp || sed -i '/ssl_prefer_server_ciphers/a ssl_client_certificate /etc/nginx/certs/ca.pem;' /etc/nginx/sites-enabled/misp
     grep -qF 'ssl_verify_client' /etc/nginx/sites-enabled/misp || sed -i "/ssl_prefer_server_ciphers/a ssl_verify_client $CERTAUTH;" /etc/nginx/sites-enabled/misp 
 

--- a/server/files/entrypoint_nginx.sh
+++ b/server/files/entrypoint_nginx.sh
@@ -172,8 +172,8 @@ if [[ $CERTAUTH = @(optional|on) ]]; then
     echo "Configure NGINX | Enabling SSL Cert Authentication"
     grep -qF "fastcgi_param SSL_CLIENT_I_DN \$ssl_client_i_dn;" /etc/nginx/snippets/fastcgi-php.conf || echo "fastcgi_param SSL_CLIENT_I_DN \$ssl_client_i_dn;" >> /etc/nginx/snippets/fastcgi-php.conf
     grep -qF "fastcgi_param SSL_CLIENT_S_DN \$ssl_client_s_dn;" /etc/nginx/snippets/fastcgi-php.conf || echo "fastcgi_param SSL_CLIENT_S_DN \$ssl_client_s_dn;" >> /etc/nginx/snippets/fastcgi-php.conf
-    grep -qF 'ssl_client_certificate' /etc/nginx/sites-enabled/misp || sed -i '/ssl_prefer_server_ciphers/a ssl_client_certificate /etc/nginx/certs/ca.pem;' /etc/nginx/sites-enabled/misp
-    grep -qF 'ssl_verify_client' /etc/nginx/sites-enabled/misp || sed -i "/ssl_prefer_server_ciphers/a ssl_verify_client $CERTAUTH;" /etc/nginx/sites-enabled/misp 
+    grep -qF 'ssl_client_certificate' /etc/nginx/sites-enabled/misp || sed -i '/ssl_prefer_server_ciphers/a \\    ssl_client_certificate /etc/nginx/certs/ca.pem;' /etc/nginx/sites-enabled/misp
+    grep -qF 'ssl_verify_client' /etc/nginx/sites-enabled/misp || sed -i "/ssl_prefer_server_ciphers/a \\    ssl_verify_client $CERTAUTH;" /etc/nginx/sites-enabled/misp 
 
     echo "Configure bootstrap | Enabling Cert Auth Plugin - Don't forget to configure it https://github.com/MISP/MISP/tree/2.4/app/Plugin/CertAuth (Step 2)" 
     sed -i "s/\/\/ CakePlugin::load('CertAuth');/CakePlugin::load('CertAuth');/" $MISP_APP_CONFIG_PATH/bootstrap.php

--- a/server/files/entrypoint_nginx.sh
+++ b/server/files/entrypoint_nginx.sh
@@ -168,6 +168,17 @@ if [[ ! "$SECURESSL" == true && ! -f /etc/nginx/certs/dhparams.pem ]]; then
     openssl dhparam -out /etc/nginx/certs/dhparams.pem 2048
 fi
 
+if [[ $CERTAUTH = @(optional|on) ]]; then
+    echo "Configure NGINX | Enabling SSL Cert Authentication"
+    grep -qxF 'fastcgi_param SSL_CLIENT_I_DN $ssl_client_i_dn;' /etc/nginx/snippets/fastcgi-php.conf || echo 'fastcgi_param SSL_CLIENT_I_DN $ssl_client_i_dn;' >> /etc/nginx/snippets/fastcgi-php.conf
+    grep -qxF 'fastcgi_param SSL_CLIENT_S_DN $ssl_client_s_dn;' /etc/nginx/snippets/fastcgi-php.conf || echo 'fastcgi_param SSL_CLIENT_S_DN $ssl_client_s_dn;' >> /etc/nginx/snippets/fastcgi-php.conf
+    grep -qF 'ssl_client_certificate' /etc/nginx/sites-enabled/misp || sed -i '/ssl_prefer_server_ciphers/a ssl_client_certificate /etc/nginx/certs/ca.pem;' /etc/nginx/sites-enabled/misp
+    grep -qF 'ssl_verify_client' /etc/nginx/sites-enabled/misp || sed -i "/ssl_prefer_server_ciphers/a ssl_verify_client $CERTAUTH;" /etc/nginx/sites-enabled/misp 
+
+    echo "Configure bootstrap | Enabling Cert Auth Plugin - Don't forget to configure it https://github.com/MISP/MISP/tree/2.4/app/Plugin/CertAuth (Step 2)" 
+    sed -i "s/\/\/ CakePlugin::load('CertAuth');/CakePlugin::load('CertAuth');/" $MISP_APP_CONFIG_PATH/bootstrap.php
+fi
+
 if [[ "$DISIPV6" == true ]]; then
     echo "Configure NGINX | Disabling IPv6"
     sed -i "s/listen \[\:\:\]/\#listen \[\:\:\]/" /etc/nginx/sites-enabled/misp80

--- a/server/files/entrypoint_nginx.sh
+++ b/server/files/entrypoint_nginx.sh
@@ -170,8 +170,8 @@ fi
 
 if [[ $CERTAUTH = @(optional|on) ]]; then
     echo "Configure NGINX | Enabling SSL Cert Authentication"
-    grep -qxF 'fastcgi_param SSL_CLIENT_I_DN $ssl_client_i_dn;' /etc/nginx/snippets/fastcgi-php.conf || echo "fastcgi_param SSL_CLIENT_I_DN \$ssl_client_i_dn;" >> /etc/nginx/snippets/fastcgi-php.conf
-    grep -qxF 'fastcgi_param SSL_CLIENT_S_DN $ssl_client_s_dn;' /etc/nginx/snippets/fastcgi-php.conf || echo "fastcgi_param SSL_CLIENT_S_DN \$ssl_client_s_dn;" >> /etc/nginx/snippets/fastcgi-php.conf
+    grep -qF "fastcgi_param SSL_CLIENT_I_DN \$ssl_client_i_dn;" /etc/nginx/snippets/fastcgi-php.conf || echo "fastcgi_param SSL_CLIENT_I_DN \$ssl_client_i_dn;" >> /etc/nginx/snippets/fastcgi-php.conf
+    grep -qF "fastcgi_param SSL_CLIENT_S_DN \$ssl_client_s_dn;" /etc/nginx/snippets/fastcgi-php.conf || echo "fastcgi_param SSL_CLIENT_S_DN \$ssl_client_s_dn;" >> /etc/nginx/snippets/fastcgi-php.conf
     grep -qF 'ssl_client_certificate' /etc/nginx/sites-enabled/misp || sed -i '/ssl_prefer_server_ciphers/a ssl_client_certificate /etc/nginx/certs/ca.pem;' /etc/nginx/sites-enabled/misp
     grep -qF 'ssl_verify_client' /etc/nginx/sites-enabled/misp || sed -i "/ssl_prefer_server_ciphers/a ssl_verify_client $CERTAUTH;" /etc/nginx/sites-enabled/misp 
 


### PR DESCRIPTION
This replaces https://github.com/coolacid/docker-misp/pull/106 and encompasses the full scope required to use certificate authentication.