### PR TITLE
Bump composer and aiohttp version

### DIFF
--- a/modules/Dockerfile
+++ b/modules/Dockerfile
@@ -19,7 +19,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     WORKDIR /srv
 
     RUN git clone --branch ${MODULES_TAG} --depth 1  https://github.com/MISP/misp-modules.git /srv/misp-modules; \
-        cd /srv/misp-modules || exit; sed -i 's/-e //g' REQUIREMENTS; pip3 wheel -r REQUIREMENTS --no-cache-dir -w /wheel/
+        cd /srv/misp-modules || exit; sed -i -e 's/-e //g' -e 's/aiohttp==3.7.3;/aiohttp==3.7.4.post0;/g' REQUIREMENTS; \
+        pip3 wheel -r REQUIREMENTS --no-cache-dir -w /wheel/
 
     RUN git clone --depth 1 https://github.com/stricaud/faup.git /srv/faup; \
         cd /srv/faup/build || exit; cmake .. && make install; \

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM composer:1.9 as composer-build
+FROM composer:2.1 as composer-build
     ARG MISP_TAG
     WORKDIR /tmp
     ADD https://raw.githubusercontent.com/MISP/MISP/${MISP_TAG}/app/composer.json /tmp


### PR DESCRIPTION
This will remove the following warnings when bulding the module docker:

* Warning from https://repo.packagist.org: Support for Composer 1 is deprecated and some packages will not be available. You should upgrade to Composer 2. See https://blog.packagist.com/deprecating-composer-1-support/


* aiohttp 3.7.3 requires chardet<4.0,>=2.0, but you'll have chardet 4.0.0 which is incompatible.
