### PR TITLE
Add ports to services

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,9 +4,13 @@ services:
   # See: https://hub.docker.com/r/namshi/smtp
   mail:
     image: namshi/smtp
+    ports:
+      - "25:25"
 
   redis:
     image: redis:5.0.6
+    ports:
+      - "6379:6379"
 
   db:
     image: mysql:8.0.19
@@ -21,6 +25,8 @@ services:
       - mysql_data:/var/lib/mysql
     cap_add:
       - SYS_NICE  # CAP_SYS_NICE Prevent runaway mysql log
+    ports:
+      - "3306:3306"
 
   misp:
     image: coolacid/misp-docker:core-latest


### PR DESCRIPTION
This adds ports to the services. It doesn't have any impact on the MISP instance, but makes it easier to create SELinux policies using [Udica](https://github.com/containers/udica).

I understand that the Compose file is there to support a quick-start - though I think it is still helpful to try out SELinux policies using Udica and the quick-start, rather than deploying these services individually.

For example, without the ports specified, SELinux policies created with Udica are missing the port definitions:
```
(block misp-mysql
    (blockinherit container)
    (allow process process ( capability ( chown dac_override fowner fsetid kill net_bind_service net_raw setfcap setgid setpcap setuid sys_chroot sys_nice ))) 

    (allow process container_file_t ( dir ( add_name create getattr ioctl lock open read remove_name rmdir search setattr write ))) 
    (allow process container_file_t ( file ( append create getattr ioctl lock map open read rename setattr unlink write ))) 
    (allow process container_file_t ( sock_file ( append getattr open read write )))
```
This means that SELinux will still create denials when the container attempts to listen on the socket. With the ports defined in the Compose file, the SELinux policy is created correctly:
```
(block misp-mysql
    (blockinherit container)
    (blockinherit restricted_net_container)
    (allow process process ( capability ( chown dac_override fowner fsetid kill net_bind_service net_raw setfcap setgid setpcap setuid sys_chroot sys_nice ))) 

    (allow process mysqld_port_t ( tcp_socket (  name_bind ))) 
    (allow process container_file_t ( dir ( add_name create getattr ioctl lock open read remove_name rmdir search setattr write ))) 
    (allow process container_file_t ( file ( append create getattr ioctl lock map open read rename setattr unlink write ))) 
    (allow process container_file_t ( sock_file ( append getattr open read write )))
```