### PR TITLE
libffi-dev needed for v2.4.149

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -33,6 +33,7 @@ FROM debian:buster-slim as python-build
         python3-setuptools \
         python3-wheel \
         libfuzzy-dev \
+        libffi-dev \
         ca-certificates \
         && apt-get autoremove -y && apt-get clean -y && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
```
  building '_cffi_backend' extension
  creating build/temp.linux-x86_64-3.7
  creating build/temp.linux-x86_64-3.7/c
  x86_64-linux-gnu-gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC -DUSE__THREAD -DHAVE_SYNC_SYNCHRONIZE -I/usr/include/ffi -I/usr/include/libffi -I/usr/include/python3.7m -c c/_cffi_backend.c -o build/temp.linux-x86_64-3.7/c/_cffi_backend.o
  c/_cffi_backend.c:15:10: fatal error: ffi.h: No such file or directory
   #include <ffi.h>
            ^~~~~~~
  compilation terminated.
  error: command 'x86_64-linux-gnu-gcc' failed with exit status 1
  
  ----------------------------------------
  Failed building wheel for cffi
  Running setup.py clean for cffi
Failed to build cffi
ERROR: Failed to build one or more wheels
The command '/bin/sh -c pip3 wheel 'cryptography>=3.3.0,<3.4.0' --no-cache-dir -w /wheels/' returned a non-zero code: 1
ERROR: Job failed: exit code 1
```