### PR TITLE
misp-modules v2.4.150 requires python 3.8 or a downgrade of sigmatools

### DIFF
--- a/modules/Dockerfile
+++ b/modules/Dockerfile
@@ -18,6 +18,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     RUN mkdir /wheel
     WORKDIR /srv
 
+    # TODO: remove downgrade of sigmatools when we have Python 3.8 ref #128 and #143
     RUN git clone --branch ${MODULES_TAG} --depth 1  https://github.com/MISP/misp-modules.git /srv/misp-modules; \
         cd /srv/misp-modules || exit; \
         sed -i 's/-e //g' -e 's/sigmatools==0.20/sigmatools==0.19.1/' REQUIREMENTS; \


### PR DESCRIPTION
misp-modules v2.4.150 requires python 3.8 or a downgrade of sigmatools