### PR TITLE
Typo in sigmatools patch, when using multiple expression with sed, al…

### DIFF
--- a/modules/Dockerfile
+++ b/modules/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     # TODO: remove downgrade of sigmatools when we have Python 3.8 ref #128 and #143
     RUN git clone --branch ${MODULES_TAG} --depth 1  https://github.com/MISP/misp-modules.git /srv/misp-modules; \
         cd /srv/misp-modules || exit; \
-        sed -i 's/-e //g' -e 's/sigmatools==0.20/sigmatools==0.19.1/' REQUIREMENTS; \
+        sed -i -e 's/-e //g' -e 's/sigmatools==0.20/sigmatools==0.19.1/' REQUIREMENTS; \
         pip3 wheel -r REQUIREMENTS --no-cache-dir -w /wheel/
 
     RUN git clone --depth 1 https://github.com/stricaud/faup.git /srv/faup; \


### PR DESCRIPTION
Typo in sigmatools patch, when using multiple expression with sed, all must have -e prefix.

Sorry about the extra work, didn't notice the slip because the build appeared to be working.