### PR TITLE
Add ability to set timezone in PHP

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,6 +51,7 @@ services:
 #      - "NOREDIR=true" # Do not redirect port 80
 #      - "DISIPV6=true" # Disable IPV6 in nginx
 #      - "CERTAUTH=optional" # Can be set to optional or on - Step 2 of https://github.com/MISP/MISP/tree/2.4/app/Plugin/CertAuth is still required
+#      - "PHP_TIMEZONE=Europe/Oslo" # Set timezone in PHP FPM https://www.php.net/manual/en/timezones.php
 #      - "SECURESSL=true" # Enable higher security SSL in nginx
 #      - "MISP_MODULES_FQDN=http://misp-modules" # Set the MISP Modules FQDN, used for Enrichment_services_url/Import_services_url/Export_services_url
 #      - "WORKERS=1" #If set to a value larger than 1 this will increase the number of parallel worker processes

--- a/server/files/entrypoint_fpm.sh
+++ b/server/files/entrypoint_fpm.sh
@@ -8,6 +8,10 @@ change_php_vars(){
         sed -i "s/max_execution_time = .*/max_execution_time = 300/" "$FILE"
         sed -i "s/upload_max_filesize = .*/upload_max_filesize = 50M/" "$FILE"
         sed -i "s/post_max_size = .*/post_max_size = 50M/" "$FILE"
+        if [ ! -z "$PHP_TIMEZONE" ];
+        then
+            sed -i -E "s|^;?date.timezone =.*$|date.timezone = $PHP_TIMEZONE|" "$FILE"
+        fi
     done
 }
 


### PR DESCRIPTION
I haven't seen this mentioned in any issues, but it is something I would like to see added myself.

It adds an ability to set time timezone directly in PHP.

If this is used you won't need to override the timezone in MISP itself. I.e. here:
https://github.com/MISP/MISP/blob/7283c8183ac5144f3cbc6f415dd6b1329a4435fa/app/Config/core.default.php#L243-L247

I've tried to follow the same coding style like I've seen in other scripts. Happy to hear any comments/thoughts.