### PR TITLE
Change from HOSTNAME to BASEURL env var

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,7 +37,7 @@ services:
       - "./ssl/:/etc/nginx/certs"
 #      - "./examples/custom-entrypoint.sh:/custom-entrypoint.sh" # Use the example custom-entrypoint.sh
     environment:
-      - "HOSTNAME=https://localhost"
+      - "BASEURL=https://localhost"
       - "REDIS_FQDN=redis"
       - "INIT=true"             # Initialze MISP, things includes, attempting to import SQL and the Files DIR
       - "CRON_USER_ID=1"        # The MISP user ID to run cron jobs as

--- a/server/files/entrypoint_nginx.sh
+++ b/server/files/entrypoint_nginx.sh
@@ -34,7 +34,7 @@ init_misp_config(){
 
     echo "Configure sane defaults"
     /var/www/MISP/app/Console/cake Admin setSetting "MISP.redis_host" "$REDIS_FQDN"
-    /var/www/MISP/app/Console/cake Admin setSetting "MISP.baseurl" "$HOSTNAME"
+    /var/www/MISP/app/Console/cake Admin setSetting "MISP.baseurl" "$BASEURL"
     /var/www/MISP/app/Console/cake Admin setSetting "MISP.python_bin" $(which python3)
 
     /var/www/MISP/app/Console/cake Admin setSetting "Plugin.ZeroMQ_redis_host" "$REDIS_FQDN"
@@ -120,6 +120,12 @@ for CERT in cert.pem dhparams.pem key.pem; do
     fi
 done
 
+# Keep backward compatibility after change from HOSTNAME to BASEURL. See issue #151
+if [ -z "$BASEURL" ]; then
+    WARNING151=true
+    BASEURL="$HOSTNAME"
+fi
+
 # Things we should do when we have the INITIALIZE Env Flag
 if [[ "$INIT" == true ]]; then
     echo "Setup MySQL..." && init_mysql
@@ -203,6 +209,12 @@ if [[ "$WARNING53" == true ]]; then
     echo "The SSL certs have moved. You currently have them mounted to /etc/ssl/certs."
     echo "This needs to be changed to /etc/nginx/certs."
     echo "See: https://github.com/coolacid/docker-misp/issues/53"
+    echo "WARNING - WARNING - WARNING"
+fi
+
+if [[ "$WARNING151" == true ]]; then
+    echo "WARNING - WARNING - WARNING"
+    echo "HOSTNAME environment variable is deprecated. Use BASEURL instead."
     echo "WARNING - WARNING - WARNING"
 fi
 


### PR DESCRIPTION
Intended to fix #151 

If you still use `HOSTNAME` and the backwards compatibility implemented here, the `BASEURL` will only be available in the `entrypoint_nginx.sh` script itself. E.g. not if you do:
```
docker exec -it mymispcontainer bash -c 'echo $HOSTNAME , $BASEURL'
```

I do not believe this is an issue. It's only needed in the `entrypoint_nginx.sh` script.

I've tried to follow the other parts of the script and place the changes where it seem natural.