### PR TITLE
Remove hardcoded arch-specific path in php-builder

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -19,7 +19,7 @@ FROM debian:bullseye-slim as php-build
         && apt-get autoremove -y && apt-get clean -y && rm -rf /var/lib/apt/lists/*
         
         RUN pecl channel-update pecl.php.net
-        RUN cp /usr/lib/x86_64-linux-gnu/libfuzzy.* /usr/lib; pecl install ssdeep && pecl install rdkafka
+        RUN cp "/usr/lib/$(gcc -dumpmachine)"/libfuzzy.* /usr/lib; pecl install ssdeep && pecl install rdkafka
         RUN git clone --recursive --depth=1 https://github.com/kjdev/php-ext-brotli.git && cd php-ext-brotli && phpize && ./configure && make && make install
         
 


### PR DESCRIPTION
Fixes #164 