### PR TITLE
Allow composer/installers to execute code / tmp/Plugin: file does not exist

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -2,7 +2,8 @@ FROM composer:2.2 as composer-build
     ARG MISP_TAG
     WORKDIR /tmp
     ADD https://raw.githubusercontent.com/MISP/MISP/${MISP_TAG}/app/composer.json /tmp
-    RUN composer install --ignore-platform-reqs && \
+    RUN composer config --no-plugins allow-plugins.composer/installers true && \ 
+     composer install --ignore-platform-reqs && \
      composer require jakub-onderka/openid-connect-php:1.0.0-rc1 --ignore-platform-reqs
 
 FROM debian:bullseye-slim as php-build


### PR DESCRIPTION
This appears to be the correct fix for this new error
````
...

composer/installers contains a Composer plugin which is blocked by your allow-plugins config. 
You may add it to the list if you consider it safe. See https://getcomposer.org/allow-plugins
You can run "composer config --no-plugins allow-plugins.composer/installers [true|false]" to 
enable it (true) or keep it disabled and suppress this warning (false)

...

Step 36/55 : COPY --from=composer-build /tmp/Vendor /var/www/MISP/app/Vendor
 ---> 7f6834a577d1
Step 37/55 : COPY --from=composer-build /tmp/Plugin /var/www/MISP/app/Plugin
COPY failed: stat tmp/Plugin: file does not exist
````

https://getcomposer.org/doc/06-config.md#allow-plugins