### PR TITLE
Use official mysql image to improve compatibility with ARM

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     image: redis:5.0.6
 
   db:
-    image: mysql:8.0.19
+    image: mysql/mysql-server:8.0
     command: --default-authentication-plugin=mysql_native_password
     restart: always
     environment:


### PR DESCRIPTION
If MariaDB is an option I would move to `image: mariadb:10.8.2` (tested on both x64 and arm64)