### PR TITLE
Use image compatible with namshi/smtp but up-to-date and supporting ARM

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,9 @@
 version: '3'
 services:
-  # This is capible to relay via gmail, Amazon SES, or generic relays
-  # See: https://hub.docker.com/r/namshi/smtp
+  # This is capable to relay via gmail, Amazon SES, or generic relays
+  # See: https://hub.docker.com/r/ixdotai/smtp
   mail:
-    image: namshi/smtp
+    image: ixdotai/smtp
 
   redis:
     image: redis:5.0.6


### PR DESCRIPTION
Note that namshi/smtp seems to be discontinued as per https://github.com/namshi/docker-smtp/issues/83