### PR TITLE
Fix the cron job updating object templates

### DIFF
--- a/server/files/entrypoint_cron.sh
+++ b/server/files/entrypoint_cron.sh
@@ -9,7 +9,7 @@ cat << EOF > /etc/cron.d/misp
 10 3 * * * www-data /var/www/MISP/app/Console/cake Admin updateTaxonomies >/tmp/cronlog 2>/tmp/cronlog
 20 3 * * * www-data /var/www/MISP/app/Console/cake Admin updateWarningLists >/tmp/cronlog 2>/tmp/cronlog
 30 3 * * * www-data /var/www/MISP/app/Console/cake Admin updateNoticeLists >/tmp/cronlog 2>/tmp/cronlog
-45 3 * * * www-data /var/www/MISP/app/Console/cake Admin updateObjectTemplates >/tmp/cronlog 2>/tmp/cronlog
+45 3 * * * www-data /var/www/MISP/app/Console/cake Admin updateObjectTemplates "$CRON_USER_ID" >/tmp/cronlog 2>/tmp/cronlog
 
 EOF
 

--- a/server/files/etc/supervisor/supervisor.conf
+++ b/server/files/etc/supervisor/supervisor.conf
@@ -34,7 +34,6 @@ stderr_logfile_maxbytes=0
 autostart=true
 
 [program:cron]
-environment=CRON_USER_ID=%(ENV_CRON_USER_ID)s
 command=/entrypoint_cron.sh
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0


### PR DESCRIPTION
Change-set also remove `environment=CRON_USER_ID=%(ENV_CRON_USER_ID)s` because

> Subprocesses will inherit the environment of the shell used to start the supervisord program

from http://supervisord.org/subprocess.html#subprocess-environment

This means that both `CRON_USER_ID` and `SYNCSERVERS` are available to the `entrypoint_cron.sh` script.