### PR TITLE
Install python packages through pip, not system manager

### DIFF
--- a/modules/Dockerfile
+++ b/modules/Dockerfile
@@ -6,13 +6,16 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
                 cmake \
                 git \
                 python3-dev \
-                python3-pip \
-                python3-wheel \
                 build-essential \
                 pkg-config \
                 libpoppler-cpp-dev \
                 libfuzzy-dev \
                 libssl-dev \
+            && curl -fsSL -O https://bootstrap.pypa.io/get-pip.py \
+            && python3 get-pip.py --no-cache-dir \
+            && rm -f get-pip.py \
+            && python3 -m pip install --no-cache-dir --no-python-version-warning --disable-pip-version-check --no-color \
+                wheel \
             && apt-get autoremove -y && apt-get clean -y && rm -rf /var/lib/apt/lists/*
 
 # Build MISP Modules

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -17,11 +17,10 @@ FROM debian:bullseye-slim as php-build
         librdkafka-dev \
         git \
         && apt-get autoremove -y && apt-get clean -y && rm -rf /var/lib/apt/lists/*
-        
+
         RUN pecl channel-update pecl.php.net
         RUN cp "/usr/lib/$(gcc -dumpmachine)"/libfuzzy.* /usr/lib; pecl install ssdeep && pecl install rdkafka
         RUN git clone --recursive --depth=1 https://github.com/kjdev/php-ext-brotli.git && cd php-ext-brotli && phpize && ./configure && make && make install
-        
 
 FROM debian:bullseye-slim as python-build
     RUN apt-get update; apt-get install -y --no-install-recommends \
@@ -29,12 +28,15 @@ FROM debian:bullseye-slim as python-build
         git \
         python3 \
         python3-dev \
-        python3-pip \
-        python3-setuptools \
-        python3-wheel \
         libfuzzy-dev \
         libffi-dev \
         ca-certificates \
+        && curl -fsSL -O https://bootstrap.pypa.io/get-pip.py \
+        && python3 get-pip.py --no-cache-dir \
+        && rm -f get-pip.py \
+        && python3 -m pip install --no-cache-dir --no-python-version-warning --disable-pip-version-check --no-color \
+            wheel \
+            setuptools \
         && apt-get autoremove -y && apt-get clean -y && rm -rf /var/lib/apt/lists/*
 
     RUN mkdir /wheels
@@ -103,8 +105,6 @@ ARG PHP_VER
         rsync \
         # Python Requirements
         python3 \
-        python3-setuptools \
-        python3-pip \
         # PHP Requirements
         php \
         php-apcu \
@@ -122,6 +122,11 @@ ARG PHP_VER
         libbrotli1 \
         # Unsure we need these
         zip unzip \
+        && curl -fsSL -O https://bootstrap.pypa.io/get-pip.py \
+        && python3 get-pip.py --no-cache-dir \
+        && rm -f get-pip.py \
+        && python3 -m pip install --no-cache-dir --no-python-version-warning --disable-pip-version-check --no-color \
+            wheel \
         && apt-get autoremove -y && apt-get clean -y && rm -rf /var/lib/apt/lists/*
 
 # MISP code
@@ -142,7 +147,7 @@ ARG PHP_VER
 
     COPY --from=composer-build /tmp/Vendor /var/www/MISP/app/Vendor
     COPY --from=composer-build /tmp/Plugin /var/www/MISP/app/Plugin
-    
+
     RUN for dir in /etc/php/*; do echo "extension=rdkafka.so" > "$dir/mods-available/rdkafka.ini"; done; phpenmod rdkafka
     RUN for dir in /etc/php/*; do echo "extension=brotli.so" > "$dir/mods-available/brotli.ini"; done; phpenmod brotli
 


### PR DESCRIPTION
This changes installation of wheel, setuptools, and pip to be conducted through pip rather than using the OS package manager python3-xxx versions. The package manager versions are outdated and subject to unpatched security vulnerabilities.