### PR TITLE
Use fastcgi_split_path_info so MISP can search for things ending in .php

### DIFF
--- a/server/files/etc/nginx/misp
+++ b/server/files/etc/nginx/misp
@@ -43,9 +43,12 @@ server {
         try_files $uri $uri/ /index.php$is_args$query_string;
     }
 
-    location ~ \.php$ {
+    location ~ ^/[^/]+\.php(/|$) {
         include snippets/fastcgi-php.conf;
         fastcgi_pass unix:/var/run/php/php7.4-fpm.sock;
         fastcgi_read_timeout 300;
+        fastcgi_split_path_info ^(.+\.php)(/.+)$;
+        set $path_info $fastcgi_path_info;
+        fastcgi_param PATH_INFO $path_info;
     }
 }

--- a/server/files/etc/nginx/misp-secure
+++ b/server/files/etc/nginx/misp-secure
@@ -41,9 +41,12 @@ server {
         try_files $uri $uri/ /index.php$is_args$query_string;
     }
 
-    location ~ \.php$ {
+    location ~ ^/[^/]+\.php(/|$) {
         include snippets/fastcgi-php.conf;
         fastcgi_pass unix:/var/run/php/php7.4-fpm.sock;
         fastcgi_read_timeout 300;
+        fastcgi_split_path_info ^(.+\.php)(/.+)$;
+        set $path_info $fastcgi_path_info;
+        fastcgi_param PATH_INFO $path_info;
     }
 }


### PR DESCRIPTION
This should allow you to use the search fields to search for things such as common phishing page names like ms.php etc...

Currently, nginx is interpreting things like /searchall:ms.php as an attempt to access a local php resource named that.